### PR TITLE
Ignore bower dependencies in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-.idea/
-node_modules/
+/.idea
+/node_modules
+/lib


### PR DESCRIPTION
Updates other ignore patterns to match only the root directory, and not
any directory within the project
