### PR TITLE
Update to latest cujo lib releases

### DIFF
--- a/app/run.js
+++ b/app/run.js
@@ -1,9 +1,10 @@
-(function(curl) {
+define(['curl'], function(curl) {
 
 	var config = {
+		main: 'wire!app/main',
 		// baseUrl: '',
 		//paths: {
-			// Configure paths here
+		// Configure paths here
 		//},
 		packages: [
 			// Define application-level packages
@@ -35,7 +36,7 @@
 		//preloads: ['poly/array', 'poly/function', 'poly/json', 'poly/object', 'poly/string', 'poly/xhr']
 	};
 
-	curl(config, ['wire!app/main']).then(success, fail);
+	curl(config).then(success, fail);
 
 	// Success! curl.js indicates that your app loaded successfully!
 	function success () {
@@ -74,5 +75,4 @@
 			throw msg;
 		}
 	}
-
-})(curl);
+});

--- a/bower.json
+++ b/bower.json
@@ -2,8 +2,8 @@
 	"name": "my-awesome-cujoJS-app",
 	"version": "0.2.3",
 	"dependencies": {
-		"curl": "~0.7",
-		"wire": "~0.9",
+		"curl": "~0.7.4",
+		"wire": "~0.10",
 		"cola": "~0.1",
 		"when": "~2",
 		"meld": "~1",

--- a/index.html
+++ b/index.html
@@ -12,8 +12,7 @@
 
 	<style type="text/css">html.loading { opacity: 0; }</style>
 
-	<script src="lib/curl/src/curl.js"></script>
-	<script src="app/run.js"></script>
+	<script data-curl-run="app/run" src="lib/curl/src/curl.js"></script>
 </head>
 <body>
 <p id="errout" style="display:none"></p>


### PR DESCRIPTION
wire 0.10, curl 0.7.4, when 2.1.1. Switch to curl's new data-curl-run attr, make run.js be a module, and use main config prop.
